### PR TITLE
Add use_patslot example

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -11,7 +11,7 @@ const isServe = process.argv.includes('--serve');
 const args = {
   format: 'esm',
   logLevel: 'info',
-  entryPoints: ['./src/index.ts', './examples/use_state.ts', './examples/use_patslot.ts', './examples/use_dialog.ts'],
+  entryPoints: ['./src/index.ts', './examples/use_state.ts', './examples/use_patslot.ts', './examples/use_dialog.ts', './examples/use_patslot/index.ts', './examples/use_patslot/patslot_example.ts'],
   bundle: true,
   sourcemap: true,
   outdir: 'dist',

--- a/examples/use_patslot/index.html
+++ b/examples/use_patslot/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pattern and Slot Example</title>
+    <script src="patslot_example.js" defer></script>
+</head>
+<body>
+    <div data-slot="people">
+        <div data-pattern="person">
+            <span data-slot="name"></span>
+            <span data-slot="age"></span>
+        </div>
+    </div>
+</body>
+</html>

--- a/examples/use_patslot/index.ts
+++ b/examples/use_patslot/index.ts
@@ -1,0 +1,39 @@
+import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const readFileAsync = (filePath: string) => {
+  return new Promise<Buffer>((resolve, reject) => {
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });
+};
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.url === '/') {
+      const data = await readFileAsync(path.join(__dirname, 'index.html'));
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(data);
+    } else if (req.url === '/patslot_example.js') {
+      const data = await readFileAsync(path.join(__dirname, 'patslot_example.js'));
+      res.writeHead(200, { 'Content-Type': 'application/javascript' });
+      res.end(data);
+    } else {
+      res.writeHead(404);
+      res.end('Not Found');
+    }
+  } catch (err) {
+    res.writeHead(500);
+    res.end('Error loading file');
+  }
+});
+
+server.listen(3000, () => {
+  console.log('Server is listening on port 3000');
+});

--- a/examples/use_patslot/patslot_example.ts
+++ b/examples/use_patslot/patslot_example.ts
@@ -1,0 +1,12 @@
+import { fill_body, clone_pat } from '../../src/patslot';
+
+const examplePeople = [
+  { name: 'John Doe', age: 30 },
+  { name: 'Jane Smith', age: 25 },
+  { name: 'Alice Johnson', age: 35 }
+];
+
+window.onload = () => {
+  const clonedNodes = examplePeople.map(person => clone_pat('person', person));
+  fill_body({ people: clonedNodes });
+};


### PR DESCRIPTION
Add a more complex pattern and slot example infrastructure.

* **Add `examples/use_patslot/index.ts`**
  - Import `http` and `fs` modules from Node.js.
  - Create an HTTP server to serve `index.html` and `patslot_example.js`.
  - Listen on port 3000.
* **Add `examples/use_patslot/index.html`**
  - Create a minimal HTML5 document.
  - Link to `patslot_example.js` in the head element.
  - Add a div with a data-slot attribute "people" in the body.
  - Add a nested div with a data-pattern attribute "person" inside the "people" div.
  - Add two span tags with data-slot attributes "name" and "age" inside the "person" div.
* **Add `examples/use_patslot/patslot_example.ts`**
  - Create a constant `examplePeople` with a list of JavaScript objects containing `name` and `age` keys.
  - Add an onload handler to iterate over `examplePeople` and call `clone_pat` for each object.
  - Save the results in a list and call `fill_body` passing the cloned nodes.
* **Modify `esbuild.js`**
  - Add `./examples/use_patslot/index.ts` and `./examples/use_patslot/patslot_example.ts` to the `entryPoints` array.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fzzzy/mumulib?shareId=4170caa3-8987-415d-935b-82d2e17cfe11).